### PR TITLE
Rails 3.2.3 complains that < Gateway is a module and that it expects a C...

### DIFF
--- a/app/models/gateway/stripe.rb
+++ b/app/models/gateway/stripe.rb
@@ -1,4 +1,4 @@
-class Gateway::Stripe < Gateway
+class Gateway::Stripe < Spree::Gateway
 	preference :login, :string
 
   def provider_class


### PR DESCRIPTION
...lass (naturally). Changing it to Spree::Gateway fixes the issue.
